### PR TITLE
Updates to copy and guide intros

### DIFF
--- a/src/pages/courses/index.md
+++ b/src/pages/courses/index.md
@@ -20,9 +20,9 @@ Start your learning adventure for the Experience Platform through the courses be
 
 #### Experience Cloud Essentials
 
-Go in depth to learn about how the Adobe Experience Cloud is architected. 
+The Adobe Experience Cloud is what powers the backbone of the Adobe suite of the digital marketing tools. Understanding how it works will help you better manage and make strategic decisions around how you setup and deploy your marketing teams for success. 
 
-* [Start Learning](/courses/experience-cloud-essentials/)
+* [Start Learning](/training/aec-essentials/index.html)
 
 
 <ProductCard slots="icon, heading, text, buttons" theme="light" width="33%" />
@@ -31,7 +31,7 @@ Go in depth to learn about how the Adobe Experience Cloud is architected.
 
 #### Experience Platform Essentials
 
-Go in depth to learn about how the Adobe Experience Platform is architected
+Go deep into the inner workings of the Adobe Experience Platform from an architectural lens to better understand how it is built so that you can appropriately design, build and leverage all the capabilities it offers to deliver next-gen marketing experiences.
 
 * [Coming Soon!](index.md)
 
@@ -43,9 +43,9 @@ Go in depth to learn about how the Adobe Experience Platform is architected
 
 ![Experience Platform Foundation](images/aep-foundation.png)
 
-#### Experience Platform Foundation
+#### Experience Platform Deployment Architecture
 
-A comprehensive course that covers all aspects of the Experience Platform at a deep architectural level.
+Have you ever wondered how to deploy the Experience Platform from a geographical standpoint? Well learn about your options as well as a simple methodology for determining how best to deploy for your organization structure.
 
 * [Coming Soon!](index.md)
 

--- a/src/pages/guides/dev-console/getting-started/index.md
+++ b/src/pages/guides/dev-console/getting-started/index.md
@@ -13,6 +13,17 @@ hideBreadcrumbNav: true
 The ultimate developer destination to access Adobe APIs & SDKs, listen to near real-time Events, run functions on Runtime, or build plugins or App Builder apps.
 
 
+<AnnouncementBlock slots="heading, text, button" />
+
+### Create Your First Developer Project
+
+Get started with creating your very own Developer Project and accessing the Experience Platform APIs
+
+[Start](../create-project/index.md)
+
+<br/>
+<br/>
+
 ## What You Will Learn
 
 In the following guide you will learn about what the Developer Console is and how to use it to setup your own project to work with the Experience Platform.
@@ -27,14 +38,3 @@ In order to complete the work ahead you will need to have the appropriate permis
 - Be assigned as a Developer within the Adobe Admin Console.  [Learn more](https://helpx.adobe.com/enterprise/using/manage-developers.html)
 - Have an existing Product Profile with the appropriate Experience Platform permissions.  [Learn more](https://experienceleague.adobe.com/docs/experience-platform/access-control/home.html?lang=en)
 - Understand how Experience Platform sandboxes function.  [Learn more](https://experienceleague.adobe.com/docs/experience-platform/access-control/home.html?lang=en)
-
-<br/>
-<br/>
-
-<AnnouncementBlock slots="heading, text, button" />
-
-### Create Your First Developer Project
-
-Get started with creating your very own Developer Project and accessing the Experience Platform APIs
-
-[Start](../create-project/index.md)

--- a/src/pages/guides/postman/getting-started/index.md
+++ b/src/pages/guides/postman/getting-started/index.md
@@ -17,6 +17,17 @@ hideBreadcrumbNav: true
 Develop and build faster with Postman and Experience Platform APIs
 
 
+<AnnouncementBlock slots="heading, text, button" />
+
+### Let's Get Started
+
+Start working with the Experience Platform APIs by setting up Postman
+
+[Start](../download-install/index.md)
+
+<br/>
+<br/>
+
 ## What is Postman?
 
 Postman is a 3rd party platform purpose built for working with and using APIs. It greatly simplifies the process of working with any APIs and provides a great deal of functionality for developers. In this guide we'll walk you through how to utilize the Postman platform to work with the Experience Platform APIs.
@@ -75,14 +86,3 @@ Better understand how Postman can simplify your API work
 Utilize existing Postman collections to quickly develop with the APIs
 
 - [Learn more](https://github.com/adobe/experience-platform-postman-samples)
-
-<br/>
-<br/>
-
-<AnnouncementBlock slots="heading, text, button" />
-
-### Let's Get Started
-
-Start working with the Experience Platform APIs by setting up Postman
-
-[Start](../download-install/index.md)

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -12,7 +12,7 @@ hideBreadcrumbNav: true
 
 # Developer Experience starts here!
 
-Educating and enabling developers, architects, and engineers on the "_why_" behind the "_how_" with Experience Platform
+Educating and enabling developers, architects, and engineers on the "_why_" behind the "_how_"
 
 
 
@@ -20,7 +20,7 @@ Educating and enabling developers, architects, and engineers on the "_why_" behi
 
 ### Start Learning
 
-The Adobe Experience Cloud powers a wide breadth of Adobe applications that assist in the creation, delivery and personalization of content.  Underneath many of these applications sits the central marketing brain, the Adobe Experience Platform. The Experience Platform is a centralized marketing brain allowing for various teams to analyze data, create unified customer profile and define segments and audiences. But before you start building you must first understand the underlying components in the Experience Platform and how best to operationalize these within your own martech stacks.
+The Adobe Experience Cloud powers a wide breadth of Adobe applications that assist in the creation, delivery and personalization of content.  Underneath many of these applications sits the central marketing brain in the Adobe Experience Platform where data collection, customer profiles and segmentation starts within Adobe's CDP. Delivering those marketing experiences though happens in a variety of applications from Adobe Commerce and Experience Manager which build the glass that customers engage with to Adobe Target, Journey Optimizer, Customer Journey Analytics, Campaign and more.  Understanding the underlying components of each of these applications and how best to operationalize these within your own martech stack is crucial to delivering on the promise of personalization at scale.
 
 
 <TextBlock slots="image, heading, text, links" width="33%" />


### PR DESCRIPTION
## Description
- general copy fixes for the getting started pages of the guides
- update to site intro title and paragraph
- removed click-through to AEC Essentials and went direct to course