### PR TITLE
upgrade to non-deprecated version of actions/cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,7 @@ jobs:
           cmd: install
 
       - name: Gatsby Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             public
@@ -211,7 +211,7 @@ jobs:
           cmd: install
 
       - name: Gatsby Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             public


### PR DESCRIPTION
## Issue
v2 is deprecated and will cause errors on deploy (similar to what we've seen in https://github.com/AdobeDocsPrivate/video-reframe-api/actions/runs/13398958637/job/37428552732):
<img width="1304" alt="Screenshot 2025-02-18 at 2 55 05 PM" src="https://github.com/user-attachments/assets/dad80430-2dec-4c43-a837-826c6506f3f7" />

## Fix
upgrade to v3